### PR TITLE
Make SmarterSorting enrichment API URLs configurable via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ The `.env` file is not committed. Create one locally with per-platform credentia
 {MODEL}_BASE_URL={url}
 {MODEL}_API_KEY={api-key}
 {MODEL}_MODEL={model_version}
+
+# SmarterSorting enrichment (required when using enrichment features)
+SMARTERSORTING_API_KEY={api-key}
+SMARTERSORTING_URL={full-url-to-enrich-endpoint}
+SMARTERSORTING_BASE_URL={base-url-for-enrichment-api}
 ```
 
 Supported models: `CHATGPT`, `PERPLEX`, `CLAUDE`, `GEMINI`, `COPILOT`.

--- a/datafiniti_integration/datafiniti_smartersorting_chatgptproductfeed.md
+++ b/datafiniti_integration/datafiniti_smartersorting_chatgptproductfeed.md
@@ -245,9 +245,10 @@ DATAFINITI_API_KEY=...
 CHATGPT_API_KEY=...
 CHATGPT_MODEL=gpt-4o
 
-# Datafiniti
-# SmarterSorting
+# SmarterSorting enrichment (required when using --enrich)
 SMARTERSORTING_API_KEY=...
+SMARTERSORTING_URL=...          # Full URL to the enrichment endpoint (used by datafiniti_integration)
+SMARTERSORTING_BASE_URL=...     # Base URL for the enrichment API (used by marketing_claims)
 ```
 
 ---

--- a/datafiniti_integration/datafiniti_to_openai_feed.py
+++ b/datafiniti_integration/datafiniti_to_openai_feed.py
@@ -61,7 +61,7 @@ from datafiniti_integration.http_utils import http_get_json, http_post_json
 # Base URLs for Datafiniti and SmarterSorting.
 DATAFINITI_SEARCH_URL = "https://api.datafiniti.co/v4/products/search"
 DATAFINITI_DOWNLOAD_URL = "https://api.datafiniti.co/v4/downloads/{id}"
-SMARTERSORTING_URL = "https://ui-enrichment-service-api-production-905356271911.us-central1.run.app/api/enrich_public"
+SMARTERSORTING_URL = os.environ.get("SMARTERSORTING_URL", "")
 DATAFINITI_FETCH_FORMAT = "JSON"
 LOG_FORMAT = "%(levelname)s: %(message)s"
 DEFAULT_POLL_SECONDS = 600
@@ -209,6 +209,12 @@ def smartersorting_enrich(
     Raises:
         RuntimeError: If the API call fails.
     """
+    if not SMARTERSORTING_URL:
+        raise RuntimeError(
+            "SMARTERSORTING_URL environment variable is not set. "
+            "Please set it to the SmarterSorting enrichment endpoint URL."
+        )
+
     payload: Dict[str, Any] = {"upc": upc}
     if product_name:
         payload["product_name"] = product_name

--- a/marketing_claims/enrichment_client.py
+++ b/marketing_claims/enrichment_client.py
@@ -8,13 +8,14 @@ available (via ``enrich_product_by_name``).
 
 import json
 import logging
+import os
 import urllib.request
 import urllib.error
 import urllib.parse
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_BASE_URL = "https://ui-enrichment-service-api-production-905356271911.us-central1.run.app"
+DEFAULT_BASE_URL = os.environ.get("SMARTERSORTING_BASE_URL", "")
 
 
 def enrich_product(upc, auth_token, base_url=None, product_name=None):
@@ -30,6 +31,12 @@ def enrich_product(upc, auth_token, base_url=None, product_name=None):
         dict with enrichment data or error information.
     """
     base = (base_url or DEFAULT_BASE_URL).rstrip("/")
+    if not base:
+        return {
+            "success": False,
+            "error": "SMARTERSORTING_BASE_URL environment variable is not set. "
+                     "Please set it to the SmarterSorting enrichment base URL.",
+        }
     url = f"{base}/api/enrich_public"
 
     auth_value = auth_token if auth_token.startswith("Bearer ") else f"Bearer {auth_token}"
@@ -76,6 +83,12 @@ def enrich_product_by_name(product_name, auth_token, base_url=None):
         dict with enrichment data or error information.
     """
     base = (base_url or DEFAULT_BASE_URL).rstrip("/")
+    if not base:
+        return {
+            "success": False,
+            "error": "SMARTERSORTING_BASE_URL environment variable is not set. "
+                     "Please set it to the SmarterSorting enrichment base URL.",
+        }
     url = f"{base}/api/enrich_public"
 
     auth_value = auth_token if auth_token.startswith("Bearer ") else f"Bearer {auth_token}"

--- a/marketing_claims/templates/index.html
+++ b/marketing_claims/templates/index.html
@@ -71,8 +71,8 @@
                     <input type="password" id="enrichment-token" placeholder="Bearer token for enrichment API">
                 </div>
                 <div class="form-group">
-                    <label>Enrichment API Base URL <span class="hint">(optional — defaults to production)</span></label>
-                    <input type="url" id="enrichment-url" placeholder="https://ui-enrichment-service-api-production-905356271911.us-central1.run.app">
+                    <label>Enrichment API Base URL <span class="hint">(required for enrichment)</span></label>
+                    <input type="url" id="enrichment-url" placeholder="https://your-enrichment-api.example.com">
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
This PR removes hardcoded SmarterSorting API URLs and makes them configurable through environment variables, improving flexibility for different deployment environments.

## Key Changes
- **marketing_claims/enrichment_client.py**: 
  - Changed `DEFAULT_BASE_URL` from hardcoded production URL to `os.environ.get("SMARTERSORTING_BASE_URL", "")`
  - Added validation in `enrich_product()` and `enrich_product_by_name()` to return error responses when the environment variable is not set

- **datafiniti_integration/datafiniti_to_openai_feed.py**:
  - Changed `SMARTERSORTING_URL` from hardcoded production URL to `os.environ.get("SMARTERSORTING_URL", "")`
  - Added validation in `smartersorting_enrich()` to raise `RuntimeError` when the environment variable is not set

- **Documentation updates**:
  - Updated README.md to document both `SMARTERSORTING_URL` and `SMARTERSORTING_BASE_URL` environment variables
  - Updated datafiniti_smartersorting_chatgptproductfeed.md to clarify the purpose of each URL variable
  - Updated marketing_claims/templates/index.html to reflect that enrichment API URL is now required and updated placeholder text

## Implementation Details
- Two separate environment variables are used: `SMARTERSORTING_URL` (full endpoint URL for datafiniti integration) and `SMARTERSORTING_BASE_URL` (base URL for marketing_claims client)
- Both modules now validate that their respective environment variables are set before making API calls
- Error handling differs between modules: enrichment_client returns error dicts, while datafiniti_to_openai_feed raises RuntimeError
- UI placeholder text updated to be more generic, removing the hardcoded production URL reference

https://claude.ai/code/session_01CSf3Amj7jj1Zm1NJaui1oN