### PR TITLE
feat: migrate benchmark LLM client to Claude on Vertex AI

### DIFF
--- a/config.py
+++ b/config.py
@@ -22,6 +22,12 @@ def load_platform_config(platform_id, env):
     base_url = _clean_env_value(env.get(f"{key_prefix}_BASE_URL"))
     api_key = _clean_env_value(env.get(f"{key_prefix}_API_KEY"))
     model = _clean_env_value(env.get(f"{key_prefix}_MODEL"))
+    # CLAUDE runs on Vertex AI via keyless ADC: no API key or base URL needed,
+    # only a model id. Configure it whenever a model is set.
+    if _uses_keyless_sdk(platform_id):
+        if not model:
+            return None
+        return {"base_url": base_url, "api_key": api_key, "model": model}
     if not api_key:
         return None
     if _requires_base_url(platform_id) and not base_url:
@@ -29,6 +35,11 @@ def load_platform_config(platform_id, env):
     if api_key.startswith("Bearer "):
         api_key = api_key[len("Bearer ") :]
     return {"base_url": base_url, "api_key": api_key, "model": model}
+
+
+def _uses_keyless_sdk(platform_id):
+    # CLAUDE (Vertex AI, keyless ADC) is SDK-backed and needs no API key.
+    return platform_id.upper() == "CLAUDE"
 
 
 def _clean_env_value(value):
@@ -42,5 +53,5 @@ def _clean_env_value(value):
 
 
 def _requires_base_url(platform_id):
-    # Gemini uses the genai SDK, others require HTTP base URL.
-    return platform_id.upper() != "GEMINI"
+    # Gemini (genai SDK) and Claude (Vertex SDK) are SDK-backed; others need a base URL.
+    return platform_id.upper() not in ("GEMINI", "CLAUDE")

--- a/marketing_claims/llm_client.py
+++ b/marketing_claims/llm_client.py
@@ -1,58 +1,51 @@
-"""LLM client abstraction for Anthropic Claude and Google Gemini APIs."""
+"""LLM client abstraction for Anthropic Claude (on Vertex AI) and Google Gemini APIs."""
 
 import json
 import logging
+import os
 import urllib.request
 import urllib.error
+
+from anthropic import AnthropicVertex
 
 logger = logging.getLogger(__name__)
 
 
-def evaluate_with_anthropic(prompt, api_key, model=None):
-    """Send evaluation prompt to Anthropic Claude API.
+def evaluate_with_anthropic(prompt, api_key=None, model=None):
+    """Send evaluation prompt to Claude on Google Vertex AI.
+
+    Uses keyless Application Default Credentials (ADC) via the AnthropicVertex
+    SDK. The calling identity needs roles/aiplatform.user on the Vertex project.
 
     Args:
         prompt: The complete evaluation prompt.
-        api_key: Anthropic API key.
-        model: Model ID (defaults to claude-sonnet-4-20250514).
+        api_key: Retained for backward compatibility; ignored (Vertex uses ADC).
+        model: Model ID (defaults to claude-sonnet-4-6).
 
     Returns:
         dict with response text or error.
     """
-    model = model or "claude-sonnet-4-20250514"
-    url = "https://api.anthropic.com/v1/messages"
-
-    payload = {
-        "model": model,
-        "max_tokens": 4096,
-        "messages": [{"role": "user", "content": prompt}],
-    }
-
-    headers = {
-        "Content-Type": "application/json",
-        "x-api-key": api_key,
-        "anthropic-version": "2023-06-01",
-    }
-
-    body = json.dumps(payload).encode("utf-8")
-    request = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    model = model or "claude-sonnet-4-6"
 
     try:
-        with urllib.request.urlopen(request, timeout=120) as response:
-            data = json.loads(response.read().decode("utf-8"))
-            # Extract text from Claude response
-            text = ""
-            for block in data.get("content", []):
-                if block.get("type") == "text":
-                    text += block.get("text", "")
-            return {"success": True, "text": text, "raw": data}
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace") if exc.fp else str(exc)
-        logger.error("Anthropic API error %s: %s", exc.code, detail)
-        return {"success": False, "error": f"Anthropic HTTP {exc.code}: {detail}"}
+        client = AnthropicVertex(
+            project_id=os.environ.get("VERTEX_PROJECT_ID", "ss-vertex-ai"),
+            region=os.environ.get("VERTEX_REGION", "global"),
+        )
+        message = client.messages.create(
+            model=model,
+            max_tokens=4096,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        # Extract text from Claude response
+        text = ""
+        for block in message.content:
+            if getattr(block, "type", None) == "text":
+                text += getattr(block, "text", "") or ""
+        return {"success": True, "text": text, "raw": message.model_dump()}
     except Exception as exc:
-        logger.error("Anthropic API unexpected error: %s", exc)
-        return {"success": False, "error": str(exc)}
+        logger.error("Vertex Anthropic API error: %s", exc)
+        return {"success": False, "error": f"Vertex Anthropic error: {exc}"}
 
 
 def evaluate_with_gemini(prompt, api_key, model=None):

--- a/marketing_claims/requirements.txt
+++ b/marketing_claims/requirements.txt
@@ -1,1 +1,2 @@
 flask>=3.0
+anthropic[vertex]>=0.40

--- a/marketing_claims/tests/stub_responses.py
+++ b/marketing_claims/tests/stub_responses.py
@@ -122,7 +122,7 @@ def _build_claude_response(analysis_json):
         "content": [
             {"type": "text", "text": json.dumps(analysis_json, indent=2)}
         ],
-        "model": "claude-sonnet-4-20250514",
+        "model": "claude-sonnet-4-6",
         "stop_reason": "end_turn",
         "usage": {"input_tokens": 1500, "output_tokens": 800},
     }

--- a/marketing_claims/tests/test_suite.py
+++ b/marketing_claims/tests/test_suite.py
@@ -138,16 +138,23 @@ class TestEnrichmentClient(unittest.TestCase):
 class TestLLMClient(unittest.TestCase):
     """Test the LLM client with mocked HTTP calls."""
 
-    @patch("marketing_claims.llm_client.urllib.request.urlopen")
-    def test_anthropic_success(self, mock_urlopen):
+    @patch("marketing_claims.llm_client.AnthropicVertex")
+    def test_anthropic_success(self, mock_vertex):
         from ..llm_client import evaluate_with_anthropic
 
         api_response = get_stub_claude_api_response("041100001214")
-        mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps(api_response).encode("utf-8")
-        mock_response.__enter__ = lambda s: s
-        mock_response.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_response
+        text = api_response["content"][0]["text"]
+
+        # Build a fake Anthropic Message with a single text block.
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = text
+        message = MagicMock()
+        message.content = [text_block]
+        message.model_dump.return_value = api_response
+
+        client = mock_vertex.return_value
+        client.messages.create.return_value = message
 
         result = evaluate_with_anthropic("test prompt", "test-key")
         self.assertTrue(result["success"])
@@ -168,16 +175,12 @@ class TestLLMClient(unittest.TestCase):
         self.assertTrue(result["success"])
         self.assertIn("overall_verdict", result["text"])
 
-    @patch("marketing_claims.llm_client.urllib.request.urlopen")
-    def test_anthropic_http_error(self, mock_urlopen):
+    @patch("marketing_claims.llm_client.AnthropicVertex")
+    def test_anthropic_error(self, mock_vertex):
         from ..llm_client import evaluate_with_anthropic
-        import urllib.error
 
-        error = urllib.error.HTTPError(
-            url="http://test", code=429, msg="Rate limited",
-            hdrs={}, fp=io.BytesIO(b"Too many requests"),
-        )
-        mock_urlopen.side_effect = error
+        client = mock_vertex.return_value
+        client.messages.create.side_effect = RuntimeError("429 Rate limited")
 
         result = evaluate_with_anthropic("test", "test-key")
         self.assertFalse(result["success"])

--- a/platform_clients.py
+++ b/platform_clients.py
@@ -18,14 +18,7 @@ def execute_prompt(platform_id, prompt, config):
         return _post_json(config["base_url"], config["api_key"], payload)
 
     if platform_id == "CLAUDE":
-        payload = _build_claude_payload(prompt, config.get("model"))
-        return _post_json(
-            config["base_url"],
-            config["api_key"],
-            payload,
-            extra_headers={"anthropic-version": "2023-06-01"},
-            auth_header="x-api-key",
-        )
+        return _execute_claude_vertex(prompt, config.get("model"))
 
     if platform_id == "GEMINI":
         raise ValueError("GEMINI requests use google-genai; call execute_gemini_prompt.")
@@ -85,6 +78,30 @@ def _build_claude_payload(prompt, model, max_tokens=1024):
         "max_tokens": max_tokens,
         "messages": [{"role": "user", "content": prompt}],
     }
+
+
+def _execute_claude_vertex(prompt, model, max_tokens=1024):
+    # Send a prompt to Claude on Vertex AI via keyless ADC and return raw JSON.
+    # Returns a JSON string in the Anthropic Messages response shape so the
+    # downstream content[] extractor keeps working unchanged.
+    try:
+        from anthropic import AnthropicVertex
+    except ImportError as exc:
+        raise ValueError(
+            "Missing anthropic[vertex]. Install with: pip install -q -U 'anthropic[vertex]'"
+        ) from exc
+
+    model = (model or "claude-sonnet-4-6").strip()
+    client = AnthropicVertex(
+        project_id=os.environ.get("VERTEX_PROJECT_ID", "ss-vertex-ai"),
+        region=os.environ.get("VERTEX_REGION", "global"),
+    )
+    message = client.messages.create(
+        model=model,
+        max_tokens=max_tokens,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return message.model_dump_json()
 
 
 def _extract_genai_text(response):


### PR DESCRIPTION
## What changed

Migrated the benchmark's Claude integration from the raw Anthropic HTTP API to **Claude on Google Vertex AI** using the official `AnthropicVertex` SDK.

- **`marketing_claims/llm_client.py`** — `evaluate_with_anthropic()` rewritten: dropped the raw `urllib.request` POST to `https://api.anthropic.com/v1/messages` and the `x-api-key` / `anthropic-version: 2023-06-01` headers. Now uses `from anthropic import AnthropicVertex` with `client.messages.create(...)`. Signature and return shape are unchanged (`{"success", "text", "raw"}` / `{"success": False, "error"}`), so callers (`app.py`) and the function-boundary tests are unaffected. The `api_key` argument is retained for compatibility but ignored (Vertex uses ADC).
- **`platform_clients.py`** — the `CLAUDE` branch of `execute_prompt()` previously also POSTed directly to the Anthropic endpoint with `x-api-key`. It now routes through a new `_execute_claude_vertex()` helper that calls `AnthropicVertex`. It returns `message.model_dump_json()` — the same Anthropic Messages `content[]` shape — so the downstream `_extract_text_response()` parser in `test_runner.py` keeps working unchanged.
- **`config.py`** — `load_platform_config()` no longer requires a `CLAUDE_API_KEY` or `CLAUDE_BASE_URL` (keyless ADC); CLAUDE is now configured whenever `CLAUDE_MODEL` is set, like GEMINI.
- **`marketing_claims/requirements.txt`** — added `anthropic[vertex]>=0.40`.

## Model

Default model `claude-sonnet-4-20250514` → **`claude-sonnet-4-6`** (in `llm_client.py`, `platform_clients.py`, and the test stub).

## Auth — keyless ADC

Uses Application Default Credentials via `AnthropicVertex(project_id=os.environ.get("VERTEX_PROJECT_ID", "ss-vertex-ai"), region=os.environ.get("VERTEX_REGION", "global"))`. No API keys. The runtime identity needs `roles/aiplatform.user` on the `ss-vertex-ai` project — request this binding via `tf-gcp-projects/vertex`.

## Tests

- The two HTTP-layer tests in `marketing_claims/tests/test_suite.py` (`test_anthropic_success`, `test_anthropic_http_error`) previously patched `marketing_claims.llm_client.urllib.request.urlopen`. Since the Claude path no longer uses `urllib`, they were rewritten to patch `marketing_claims.llm_client.AnthropicVertex` at the SDK boundary (the error test renamed to `test_anthropic_error`). They assert the same success/error behavior.
- App-level tests that patch `marketing_claims.app.evaluate_with_anthropic` at the function boundary are unchanged and still pass.
- `python3 -m py_compile` passes on every edited file. The full `TestLLMClient` suite (8 tests) passes against an installed `anthropic[vertex]`. The 4 `TestEnrichmentClient` failures are **pre-existing on `main`** (the enrichment client makes a real network call unavailable in CI) and are unrelated to this change.

## Rollback

Revert this PR (or the single commit). The previous raw-HTTP path restores the `api.anthropic.com` + `x-api-key` integration with no other coordination needed. Note: rolling back also reverts the `config.py` keyless change, so the old `CLAUDE_API_KEY` / `CLAUDE_BASE_URL` env vars would be required again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)